### PR TITLE
Adding Authentication Tests

### DIFF
--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -117,7 +117,6 @@ variants:
             - bad_sv:
                 spice_streaming_video = bad_value
 
-
         variants:
             -@default_pc:
                 spice_playback_compression = on
@@ -138,8 +137,8 @@ variants:
             -default_ipv:
                 spice_ipv4=no
                 spice_ipv6=no
-variants:
 
+variants:
     - qemu_kvm_rhel6devel_install_client:
         # Use this only when you need to create rhel6devel image qcow
         qemu_binary = /usr/libexec/qemu-kvm
@@ -230,6 +229,22 @@ variants:
         only smallpages
         only Linux.RHEL.6.devel.x86_64
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor
+        only rv_connect.RHEL.6.devel.x86_64, shutdown
+
+    - @remote_viewer_rhel6devel_password:
+        qemu_binary = /usr/libexec/qemu-kvm
+        qemu_img_binary = /usr/bin/qemu-img
+        qemu_io_binary = /usr/bin/qemu-io
+        rv_binary = /usr/bin/remote-viewer
+        only qcow2
+        only e1000
+        only ide
+        only up
+        only no_9p_export
+        only no_pci_assignable
+        only smallpages
+        only Linux.RHEL.6.devel.x86_64
+        only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.password.dcp_off.1monitor
         only rv_connect.RHEL.6.devel.x86_64, shutdown
 
     - @remote_viewer_win_guest_quick:
@@ -362,6 +377,19 @@ variants:
         only rv_connect.RHEL.6.devel.x86_64, rv_input.RHEL.6.devel.x86_64, shutdown
 
 variants:
+    - rv_connect_passwd:
+        only remote_viewer_rhel6devel_password
+    - rv_connect_wrong_passwd:
+        test_type = negative
+        spice_password_send = incorrectpass
+        only remote_viewer_rhel6devel_password
+    - rv_qemu_password:
+        qemu_password = qemupassword
+        only remote_viewer_rhel6devel_quick
+    - rv_qemu_password_overwrite:
+        qemu_password = qemupassword
+        only remote_viewer_rhel6devel_password
+
     #The following are all the individual tests for spice
     - create_vms:
         only qemu_kvm_rhel6devel_install_guest, qemu_kvm_rhel6devel_install_client
@@ -541,4 +569,4 @@ variants:
 #only copy_client_to_guest_largetext_pos, copy_guest_to_client_largetext_pos, copy_client_to_guest_pos, copy_guest_to_client_pos, copy_guest_to_client_neg, copy_client_to_guest_neg, copyimg_client_to_guest_pos, copyimg_client_to_guest_neg, copyimg_guest_to_client_pos, copyimg_guest_to_client_neg, copyimg_client_to_guest_dcp_neg, copyimg_guest_to_client_dcp_neg, copy_guest_to_client_dcp_neg, copy_client_to_guest_dcp_neg, copybmpimg_client_to_guest_pos, copybmpimg_guest_to_client_pos, copy_guest_to_client_largetext_10mb_pos, copy_client_to_guest_largetext_10mb_pos, copyimg_medium_client_to_guest_pos, copyimg_medium_guest_to_client_pos, copyimg_large_client_to_guest_pos, copyimg_large_guest_to_client_pos, restart_vdagent_copy_client_to_guest_pos, only restart_vdagent_copy_guest_to_client_pos, restart_vdagent_copyimg_client_to_guest_pos, restart_vdagent_copyimg_guest_to_client_pos, restart_vdagent_copybmpimg_client_to_guest_pos, restart_vdagent_copybmpimg_guest_to_client_pos, restart_vdagent_copy_client_to_guest_largetext_pos, restart_vdagent_copy_guest_to_client_largetext_pos
 
 #Running all Spice Tests
-only create_vms, install_win_guest, negative_qemu_spice_launch_badport, negative_qemu_spice_launch_badic, negative_qemu_spice_launch_badjpegwc, negative_qemu_spice_launch_badzlib, negative_qemu_spice_launch_badsv, negative_qemu_spice_launch_badpc, remote_viewer_test, remote_viewer_ssl_test, remote_viewer_winguest_test, remote_viewer_disconnect_test, copy_client_to_guest_largetext_pos, copy_guest_to_client_largetext_pos, copy_client_to_guest_pos, copy_guest_to_client_pos, copy_guest_to_client_neg, copy_client_to_guest_neg, copyimg_client_to_guest_pos, copyimg_client_to_guest_neg, copyimg_guest_to_client_pos, copyimg_guest_to_client_neg, copyimg_client_to_guest_dcp_neg, copyimg_guest_to_client_dcp_neg, copy_guest_to_client_dcp_neg, copy_client_to_guest_dcp_neg, copybmpimg_client_to_guest_pos, copybmpimg_guest_to_client_pos, copy_guest_to_client_largetext_10mb_pos, copy_client_to_guest_largetext_10mb_pos, copyimg_medium_client_to_guest_pos, copyimg_medium_guest_to_client_pos, copyimg_large_client_to_guest_pos, copyimg_large_guest_to_client_pos, restart_vdagent_copy_client_to_guest_pos, only restart_vdagent_copy_guest_to_client_pos, restart_vdagent_copyimg_client_to_guest_pos, restart_vdagent_copyimg_guest_to_client_pos, restart_vdagent_copybmpimg_client_to_guest_pos, restart_vdagent_copybmpimg_guest_to_client_pos, restart_vdagent_copy_client_to_guest_largetext_pos, restart_vdagent_copy_guest_to_client_largetext_pos, remote_viewer_fullscreen_test, remote_viewer_fullscreen_test_neg, spice_vdagent_logging, qxl_logging, keyboard_input_leds_and_esc_keys, keyboard_input_non-us_layout, keyboard_input_type_and_func_keys, keyboard_input_leds_migration
+only create_vms, install_win_guest, negative_qemu_spice_launch_badport, negative_qemu_spice_launch_badic, negative_qemu_spice_launch_badjpegwc, negative_qemu_spice_launch_badzlib, negative_qemu_spice_launch_badsv, negative_qemu_spice_launch_badpc, remote_viewer_test, remote_viewer_ssl_test, remote_viewer_winguest_test, remote_viewer_disconnect_test, copy_client_to_guest_largetext_pos, copy_guest_to_client_largetext_pos, copy_client_to_guest_pos, copy_guest_to_client_pos, copy_guest_to_client_neg, copy_client_to_guest_neg, copyimg_client_to_guest_pos, copyimg_client_to_guest_neg, copyimg_guest_to_client_pos, copyimg_guest_to_client_neg, copyimg_client_to_guest_dcp_neg, copyimg_guest_to_client_dcp_neg, copy_guest_to_client_dcp_neg, copy_client_to_guest_dcp_neg, copybmpimg_client_to_guest_pos, copybmpimg_guest_to_client_pos, copy_guest_to_client_largetext_10mb_pos, copy_client_to_guest_largetext_10mb_pos, copyimg_medium_client_to_guest_pos, copyimg_medium_guest_to_client_pos, copyimg_large_client_to_guest_pos, copyimg_large_guest_to_client_pos, restart_vdagent_copy_client_to_guest_pos, only restart_vdagent_copy_guest_to_client_pos, restart_vdagent_copyimg_client_to_guest_pos, restart_vdagent_copyimg_guest_to_client_pos, restart_vdagent_copybmpimg_client_to_guest_pos, restart_vdagent_copybmpimg_guest_to_client_pos, restart_vdagent_copy_client_to_guest_largetext_pos, restart_vdagent_copy_guest_to_client_largetext_pos, remote_viewer_fullscreen_test, remote_viewer_fullscreen_test_neg, spice_vdagent_logging, qxl_logging, keyboard_input_leds_and_esc_keys, keyboard_input_non-us_layout, keyboard_input_type_and_func_keys, keyboard_input_leds_migration, rv_connect_passwd, rv_connect_wrong_passwd, rv_qemu_password, rv_qemu_password_overwrite


### PR DESCRIPTION
Adding Authentication Tests:
1.  remote-viewer w/correct password
2.  remote-viewer w/incorrect password
3.  remote-viewer w/password set from qemu monitor
4.  remote-viewer w/password set from qemu monitor to overwrite the existing password.

And also separating the spice tests by platform.
