### PR TITLE
Adding two Tests for a Clean Exit on a Guest Shutdown

### DIFF
--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -280,6 +280,22 @@ variants:
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor
         only rv_connect.RHEL.6.devel.x86_64, rv_disconnect.RHEL.6.devel.x86_64, shutdown
 
+    - @rv_vmshutdown_rhel6devel:
+        qemu_binary = /usr/libexec/qemu-kvm
+        qemu_img_binary = /usr/bin/qemu-img
+        qemu_io_binary = /usr/bin/qemu-io
+        rv_binary = /usr/bin/remote-viewer
+        only qcow2
+        only e1000
+        only ide
+        only up
+        only no_9p_export
+        only no_pci_assignable
+        only smallpages
+        only Linux.RHEL.6.devel.x86_64
+        only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor
+        only rv_connect.RHEL.6.devel.x86_64, rv_vmshutdown.RHEL.6.devel.x86_64, shutdown
+
     - @rv_fullscreen_rhel6devel:
         qemu_binary = /usr/libexec/qemu-kvm
         qemu_img_binary = /usr/bin/qemu-img
@@ -533,6 +549,12 @@ variants:
     - spice_vdagent_logging:
         logtest = spice-vdagent
         only rv_logging_rhel6devel
+    - guestvmshutdown_cmd:
+        shutdownfrom = cmd
+        only rv_vmshutdown_rhel6devel
+    - guestvmshutdown_qemu:
+        shutdownfrom = qemu_monitor
+        only rv_vmshutdown_rhel6devel
 
 #Running all Logging Tests
 #only spice_vdagent_logging, qxl_logging
@@ -541,4 +563,4 @@ variants:
 #only copy_client_to_guest_largetext_pos, copy_guest_to_client_largetext_pos, copy_client_to_guest_pos, copy_guest_to_client_pos, copy_guest_to_client_neg, copy_client_to_guest_neg, copyimg_client_to_guest_pos, copyimg_client_to_guest_neg, copyimg_guest_to_client_pos, copyimg_guest_to_client_neg, copyimg_client_to_guest_dcp_neg, copyimg_guest_to_client_dcp_neg, copy_guest_to_client_dcp_neg, copy_client_to_guest_dcp_neg, copybmpimg_client_to_guest_pos, copybmpimg_guest_to_client_pos, copy_guest_to_client_largetext_10mb_pos, copy_client_to_guest_largetext_10mb_pos, copyimg_medium_client_to_guest_pos, copyimg_medium_guest_to_client_pos, copyimg_large_client_to_guest_pos, copyimg_large_guest_to_client_pos, restart_vdagent_copy_client_to_guest_pos, only restart_vdagent_copy_guest_to_client_pos, restart_vdagent_copyimg_client_to_guest_pos, restart_vdagent_copyimg_guest_to_client_pos, restart_vdagent_copybmpimg_client_to_guest_pos, restart_vdagent_copybmpimg_guest_to_client_pos, restart_vdagent_copy_client_to_guest_largetext_pos, restart_vdagent_copy_guest_to_client_largetext_pos
 
 #Running all Spice Tests
-only create_vms, install_win_guest, negative_qemu_spice_launch_badport, negative_qemu_spice_launch_badic, negative_qemu_spice_launch_badjpegwc, negative_qemu_spice_launch_badzlib, negative_qemu_spice_launch_badsv, negative_qemu_spice_launch_badpc, remote_viewer_test, remote_viewer_ssl_test, remote_viewer_winguest_test, remote_viewer_disconnect_test, copy_client_to_guest_largetext_pos, copy_guest_to_client_largetext_pos, copy_client_to_guest_pos, copy_guest_to_client_pos, copy_guest_to_client_neg, copy_client_to_guest_neg, copyimg_client_to_guest_pos, copyimg_client_to_guest_neg, copyimg_guest_to_client_pos, copyimg_guest_to_client_neg, copyimg_client_to_guest_dcp_neg, copyimg_guest_to_client_dcp_neg, copy_guest_to_client_dcp_neg, copy_client_to_guest_dcp_neg, copybmpimg_client_to_guest_pos, copybmpimg_guest_to_client_pos, copy_guest_to_client_largetext_10mb_pos, copy_client_to_guest_largetext_10mb_pos, copyimg_medium_client_to_guest_pos, copyimg_medium_guest_to_client_pos, copyimg_large_client_to_guest_pos, copyimg_large_guest_to_client_pos, restart_vdagent_copy_client_to_guest_pos, only restart_vdagent_copy_guest_to_client_pos, restart_vdagent_copyimg_client_to_guest_pos, restart_vdagent_copyimg_guest_to_client_pos, restart_vdagent_copybmpimg_client_to_guest_pos, restart_vdagent_copybmpimg_guest_to_client_pos, restart_vdagent_copy_client_to_guest_largetext_pos, restart_vdagent_copy_guest_to_client_largetext_pos, remote_viewer_fullscreen_test, remote_viewer_fullscreen_test_neg, spice_vdagent_logging, qxl_logging, keyboard_input_leds_and_esc_keys, keyboard_input_non-us_layout, keyboard_input_type_and_func_keys, keyboard_input_leds_migration
+only create_vms, install_win_guest, negative_qemu_spice_launch_badport, negative_qemu_spice_launch_badic, negative_qemu_spice_launch_badjpegwc, negative_qemu_spice_launch_badzlib, negative_qemu_spice_launch_badsv, negative_qemu_spice_launch_badpc, remote_viewer_test, remote_viewer_ssl_test, remote_viewer_winguest_test, remote_viewer_disconnect_test, copy_client_to_guest_largetext_pos, copy_guest_to_client_largetext_pos, copy_client_to_guest_pos, copy_guest_to_client_pos, copy_guest_to_client_neg, copy_client_to_guest_neg, copyimg_client_to_guest_pos, copyimg_client_to_guest_neg, copyimg_guest_to_client_pos, copyimg_guest_to_client_neg, copyimg_client_to_guest_dcp_neg, copyimg_guest_to_client_dcp_neg, copy_guest_to_client_dcp_neg, copy_client_to_guest_dcp_neg, copybmpimg_client_to_guest_pos, copybmpimg_guest_to_client_pos, copy_guest_to_client_largetext_10mb_pos, copy_client_to_guest_largetext_10mb_pos, copyimg_medium_client_to_guest_pos, copyimg_medium_guest_to_client_pos, copyimg_large_client_to_guest_pos, copyimg_large_guest_to_client_pos, restart_vdagent_copy_client_to_guest_pos, only restart_vdagent_copy_guest_to_client_pos, restart_vdagent_copyimg_client_to_guest_pos, restart_vdagent_copyimg_guest_to_client_pos, restart_vdagent_copybmpimg_client_to_guest_pos, restart_vdagent_copybmpimg_guest_to_client_pos, restart_vdagent_copy_client_to_guest_largetext_pos, restart_vdagent_copy_guest_to_client_largetext_pos, remote_viewer_fullscreen_test, remote_viewer_fullscreen_test_neg, spice_vdagent_logging, qxl_logging, keyboard_input_leds_and_esc_keys, keyboard_input_non-us_layout, keyboard_input_type_and_func_keys, keyboard_input_leds_migration, guestvmshutdown_cmd, guestvmshutdown_qemu

--- a/qemu/tests/cfg/rv_vmshutdown.cfg
+++ b/qemu/tests/cfg/rv_vmshutdown.cfg
@@ -1,0 +1,30 @@
+- rv_vmshutdown: rv_connect
+    no JeOS
+    type = rv_vmshutdown
+    vms = vm1 vm2
+    guest_vm = vm1
+    client_vm = vm2
+    image_name_vm2 = client_vm
+    display_vm2 = vnc
+    vga_vm2 = cirrus
+    virtio_ports_vm1 = "vdagent"
+    virtio_port_type_vm1 = "serialport"
+    virtio_port_chardev_vm1 = "spicevmc"
+    virtio_port_name_prefix_vm1 = "com.redhat.spice."
+    cmd_cli_shutdown = "shutdown -h now"
+    cmd_qemu_shutdown = "system_powerdown"
+
+    variants:
+        - RHEL:
+            variants:
+                # This is current solution of handling
+                # multiple guests running exact same OS
+                -6.3.x86_64:
+                    image_name_vm2 = images/rhel63-64_client
+                -6.3.i386:
+                    image_name_vm2 = images/rhel63-32_client
+                -6.devel.x86_64:
+                    image_name_vm2 = images/rhel6devel-64_client
+                -6.devel.i386:
+                    image_name_vm2 = images/rhel6devel-32_client
+

--- a/tests/rv_vmshutdown.py
+++ b/tests/rv_vmshutdown.py
@@ -1,0 +1,107 @@
+"""
+rv_vmshutdown.py - shutdown the guest and verify it is a clean exit.
+
+Requires: connected binaries remote-viewer, Xorg, gnome session
+
+"""
+import logging
+from autotest.client.shared import error
+from virttest.aexpect import ShellCmdError
+from virttest import utils_spice
+from virttest import utils_misc
+from virttest import utils_net
+
+
+def run_rv_vmshutdown(test, params, env):
+    """
+    Tests clean exit after shutting down the VM.
+    Covers two cases:
+    (1)Shutdown from the command line of the guest.
+    (2)Shutdown from the qemu monitor.
+    
+    Verify after the shutdown:
+    (1)Verifying the guest is down
+    (2)Verify the spice connection to the guest is no longer established
+    (3)Verify the remote-viewer process is not running
+
+    @param test: QEMU test object.
+    @param params: Dictionary with the test parameters.
+    @param env: Dictionary with test environment.
+    """
+    
+    #Get the required variables
+    rv_binary = params.get("rv_binary", "remote-viewer")
+    host_ip = utils_net.get_host_ip_address(params)
+    shutdownfrom = params.get("shutdownfrom")
+    cmd_cli_shutdown = params.get("cmd_cli_shutdown")
+    cmd_qemu_shutdown = params.get("cmd_qemu_shutdown")
+    kill_timeout = int(params.get("kill_timeout"))
+    host_port = None
+
+    guest_vm = env.get_vm(params["guest_vm"])
+    guest_vm.verify_alive()
+    guest_session = guest_vm.wait_for_login(
+            timeout=int(params.get("login_timeout", 360)))
+
+    client_vm = env.get_vm(params["client_vm"])
+    client_vm.verify_alive()
+    client_session = client_vm.wait_for_login(
+            timeout=int(params.get("login_timeout", 360)))
+    
+    if guest_vm.get_spice_var("spice_ssl") == "yes":
+        host_port = guest_vm.get_spice_var("spice_tls_port")
+    else:
+        host_port = guest_vm.get_spice_var("spice_port")
+
+    #Determine if the test is to shutdown from cli or qemu monitor
+    if shutdownfrom == "cmd":
+        logging.info("Shutting down guest from command line:" +
+                     " %s\n" % cmd_cli_shutdown)
+        output = guest_session.cmd(cmd_cli_shutdown)
+        logging.debug("Guest is being shutdown: %s" % output)
+    elif shutdownfrom == "qemu_monitor":
+        logging.info("Shutting down guest from qemu monitor\n")
+        output = guest_vm.monitor.cmd(cmd_qemu_shutdown)
+        logging.debug("Output of %s: %s" % (cmd_qemu_shutdown, output))
+    else:
+        raise error.TestFail("shutdownfrom var not set, valid values are" +
+                             " cmd or qemu_monitor")
+
+    #wait for the guest vm to be shutoff
+    logging.info("Waiting for the guest VM to be shutoff")
+    utils_misc.wait_for(guest_vm.is_dead, kill_timeout, 30, 1, "waiting...")
+    logging.info("Guest VM is now shutoff")
+
+    #Verify there was a clean exit by
+    #(1)Verifying the guest is down
+    #(2)Verify the spice connection to the guest is no longer established
+    #(3)Verify the remote-viewer process is not running
+    try:
+        guest_vm.verify_alive()
+        raise error.TestFail("Guest VM is still alive, shutdown failed.")
+    except Exception as exc:
+        if "VM is dead" in str(exc):
+            logging.info("Guest VM is verified to be shutdown")
+        else:
+            raise error.TestFail("Unexpected Error: %s" % exc.value())
+
+    try:
+        utils_spice.verify_established(client_vm, host_ip, host_port, rv_binary)
+        raise error.TestFail("Remote-Viewer connection to guest is still established.")
+    except utils_spice.RVConnectError:
+        logging.info("There is no remote-viewer connection as expected")
+    else:
+        raise error.TestFail("Unexpected error while trying to see if there" +
+                             " was no spice connection to the guest")
+
+    #Verify the remote-viewer process is not running
+    logging.info("Checking to see if remote-viewer process is still running on" +
+                 " client after VM has been shutdown")
+    try:
+        pidoutput = str(client_session.cmd("pgrep remote-viewer"))
+        raise error.TestFail("Remote-viewer is still running on the client.")
+    except ShellCmdError:
+        logging.info("Remote-viewer process is not running as expected.")
+    else:
+        raise error.TestFail("Unexpected error while trying to verify" +
+                             "remote-viewer process was not running.")

--- a/virttest/utils_spice.py
+++ b/virttest/utils_spice.py
@@ -2,10 +2,13 @@
 Common spice test utility functions.
 
 """
-import logging, time
+import os, logging, time
 from autotest.client.shared import error
 from aexpect import ShellCmdError, ShellStatusError, ShellTimeoutError
 
+class RVConnectError(Exception):
+    """Exception raised in case that remote-viewer fails to connect"""
+    pass
 
 def wait_timeout(timeout=10):
     """
@@ -15,6 +18,34 @@ def wait_timeout(timeout=10):
     """
     logging.debug("Waiting (timeout=%ss)", timeout)
     time.sleep(timeout)
+
+def verify_established(client_vm, host, port, rv_binary):
+    """
+    Parses netstat output for established connection on host:port
+    @param client_session - vm.wait_for_login()
+    @param host - host ip addr
+    @param port - port for client to connect
+    @param rv_binary - remote-viewer binary
+    """
+    rv_binary = rv_binary.split(os.path.sep)[-1]
+
+    client_session = client_vm.wait_for_login(timeout=60)
+
+    # !!! -n means do not resolve port names
+    cmd = '(netstat -pn 2>&1| grep "^tcp.*:.*%s:%s.*ESTABLISHED.*%s.*") \
+        > /dev/null' % (host, str(port), rv_binary)
+    try:
+        netstat_out = client_session.cmd(cmd)
+        logging.info("netstat output: %s", netstat_out)
+
+    except ShellCmdError:
+        logging.error("Failed to get established connection from netstat")
+        raise RVConnectError()
+
+    else:
+        logging.info("%s connection to %s:%s successful.",
+               rv_binary, host, port)
+    client_session.close()
 
 
 def start_vdagent(guest_session, test_timeout):


### PR DESCRIPTION
Tests:
1.  Shutdown from cli
2.  Shutdown from qemu_monitor

Verify:
1.  guest is shutdown
2. rv_connection is no longer established
3. remote-viewer process is no longer running on the client.
