### PR TITLE
Shutdown test for spice tests (client_guest_shutdown)

### DIFF
--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -214,7 +214,7 @@ variants:
         only smallpages
         only Linux.RHEL.6.devel.x86_64
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.ssl.key_password.password.dcp_off.1monitor
-        only rv_connect.RHEL.6.devel.x86_64, shutdown
+        only rv_connect.RHEL.6.devel.x86_64, client_guest_shutdown.RHEL.6.devel.x86_64
 
     - @remote_viewer_rhel6devel_quick:
         qemu_binary = /usr/libexec/qemu-kvm
@@ -230,7 +230,8 @@ variants:
         only smallpages
         only Linux.RHEL.6.devel.x86_64
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor
-        only rv_connect.RHEL.6.devel.x86_64, shutdown
+ 	only rv_connect.RHEL.6.devel.x86_64, client_guest_shutdown.RHEL.6.devel.x86_64       
+#only rv_connect.RHEL.6.devel.x86_64, client_guest_shutdown.RHEL.6.devel.x86_64
 
     - @remote_viewer_win_guest_quick:
         qemu_binary = /usr/libexec/qemu-kvm
@@ -247,7 +248,7 @@ variants:
         only Win7.64.sp1
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor
         #rv_connect_win is specifically a test meant for a windows guest and a rhel client, rv_connect cannot be used.
-        only rv_connect_win.RHEL.6.devel.x86_64, shutdown
+        only rv_connect_win.RHEL.6.devel.x86_64, client_guest_shutdown.RHEL.6.devel.x86_64
 
     - @spice_negative_rhel6devel:
         qemu_binary = /usr/libexec/qemu-kvm
@@ -278,7 +279,7 @@ variants:
         only smallpages
         only Linux.RHEL.6.devel.x86_64
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor
-        only rv_connect.RHEL.6.devel.x86_64, rv_disconnect.RHEL.6.devel.x86_64, shutdown
+        only rv_connect.RHEL.6.devel.x86_64, rv_disconnect.RHEL.6.devel.x86_64, client_guest_shutdown.RHEL.6.devel.x86_64
 
     - @rv_fullscreen_rhel6devel:
         qemu_binary = /usr/libexec/qemu-kvm
@@ -295,7 +296,7 @@ variants:
         only smallpages
         only Linux.RHEL.6.devel.x86_64
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor
-        only fullscreen_setup.RHEL.6.devel.x86_64, rv_connect.RHEL.6.devel.x86_64, rv_fullscreen.RHEL.6.devel.x86_64, shutdown
+        only fullscreen_setup.RHEL.6.devel.x86_64, rv_connect.RHEL.6.devel.x86_64, rv_fullscreen.RHEL.6.devel.x86_64, client_guest_shutdown.RHEL.6.devel.x86_64
 
     - @rv_logging_rhel6devel:
         qemu_binary = /usr/libexec/qemu-kvm
@@ -311,7 +312,7 @@ variants:
         only smallpages
         only Linux.RHEL.6.devel.x86_64
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor
-        only rv_connect.RHEL.6.devel.x86_64, rv_logging.RHEL.6.devel.x86_64, shutdown
+        only rv_connect.RHEL.6.devel.x86_64, rv_logging.RHEL.6.devel.x86_64, client_guest_shutdown.RHEL.6.devel.x86_64
 
     - @rv_copyandpaste_rhel6devel:
         qemu_binary = /usr/libexec/qemu-kvm
@@ -327,7 +328,7 @@ variants:
         only smallpages
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor
         only Linux.RHEL.6.devel.x86_64
-        only rv_connect.RHEL.6.devel.x86_64, rv_copyandpaste.RHEL.6.devel.x86_64, shutdown
+        only rv_connect.RHEL.6.devel.x86_64, rv_copyandpaste.RHEL.6.devel.x86_64, client_guest_shutdown.RHEL.6.devel.x86_64
 
     - @rv_copyandpaste_dcp_rhel6devel:
         qemu_binary = /usr/libexec/qemu-kvm
@@ -343,7 +344,7 @@ variants:
         only smallpages
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_on.1monitor
         only Linux.RHEL.6.devel.x86_64
-        only rv_connect.RHEL.6.devel.x86_64, rv_copyandpaste.RHEL.6.devel.x86_64, shutdown
+        only rv_connect.RHEL.6.devel.x86_64, rv_copyandpaste.RHEL.6.devel.x86_64, client_guest_shutdown.RHEL.6.devel.x86_64
 
     - @rv_input_rhel6devel:
         qemu_binary = /usr/libexec/qemu-kvm
@@ -359,7 +360,7 @@ variants:
         only smallpages
         only Linux.RHEL.6.devel.x86_64
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor
-        only rv_connect.RHEL.6.devel.x86_64, rv_input.RHEL.6.devel.x86_64, shutdown
+        only rv_connect.RHEL.6.devel.x86_64, rv_input.RHEL.6.devel.x86_64, client_guest_shutdown.RHEL.6.devel.x86_64
 
 variants:
     #The following are all the individual tests for spice

--- a/qemu/tests/cfg/client_guest_shutdown.cfg
+++ b/qemu/tests/cfg/client_guest_shutdown.cfg
@@ -1,0 +1,31 @@
+- client_guest_shutdown: install setup image_copy unattended_install.cdrom
+    vms = vm1 vm2
+    guest_vm = vm1
+    client_vm = vm2
+    image_name_vm2 = client_vm
+    display_vm2 = vnc
+    vga_vm2 = cirrus
+    virtio_ports_vm1 = "vdagent"
+    virtio_port_type_vm1 = "serialport"
+    virtio_port_chardev_vm1 = "spicevmc"
+    virtio_port_name_prefix_vm1 = "com.redhat.spice."
+    virt_test_type = libvirt kvm
+    type = client_guest_shutdown
+    shutdown_method = shell
+    kill_vm = yes
+    kill_vm_gracefully = no
+
+    variants:
+        - RHEL:
+            variants:
+                # This is current solution of handling
+                # multiple guests running exact same OS
+                -6.3.x86_64:
+                    image_name_vm2 = images/rhel63-64_client
+                -6.3.i386:
+                    image_name_vm2 = images/rhel63-32_client
+                -6.devel.x86_64:
+                    image_name_vm2 = images/rhel6devel-64_client
+                -6.devel.i386:
+                    image_name_vm2 = images/rhel6devel-32_client
+

--- a/tests/client_guest_shutdown.py
+++ b/tests/client_guest_shutdown.py
@@ -1,0 +1,69 @@
+import time
+from autotest.client.shared import error
+from virttest import utils_misc
+
+
+@error.context_aware
+def run_client_guest_shutdown(test, params, env):
+    """
+    KVM shutdown test:
+    For a test with two VMs: client & guest
+    1) Log into the VMS(guests) that represent the client &guest
+    2) Send a shutdown command to the guest, or issue a system_powerdown
+       monitor command (depending on the value of shutdown_method)
+    3) Wait until the guest is down
+
+    @param test: kvm test object
+    @param params: Dictionary with the test parameters
+    @param env: Dictionary with test environment
+    """
+    client_vm = env.get_vm(params["client_vm"]) 
+    client_vm.verify_alive()
+    guest_vm = env.get_vm(params["guest_vm"])
+    guest_vm.verify_alive()
+
+    timeout = int(params.get("login_timeout", 360))
+    client_session = client_vm.wait_for_login(timeout=timeout)
+    guest_session = guest_vm.wait_for_login(timeout=timeout)
+
+    #shutdown the client session
+    try:
+        error.base_context("shutting down the VM")
+        if params.get("shutdown_method") == "shell":
+            # Send a shutdown command to the guest's shell
+            client_session.sendline(client_vm.get_params().get("shutdown_command"))
+            error.context("waiting VM to go down (shutdown shell cmd)")
+        elif params.get("shutdown_method") == "system_powerdown":
+            # Sleep for a while -- give the guest a chance to finish booting
+            time.sleep(float(params.get("sleep_before_powerdown", 10)))
+            # Send a system_powerdown monitor command
+            client_vm.monitor.cmd("system_powerdown")
+            error.context("waiting VM to go down "
+                          "(system_powerdown monitor cmd)")
+
+        if not utils_misc.wait_for(client_vm.is_dead, 240, 0, 1):
+            raise error.TestFail("Guest refuses to go down")
+
+    finally:
+        client_session.close()
+
+    #shutdown the guest session
+    try:
+        error.base_context("shutting down the guest VM")
+        if params.get("shutdown_method") == "shell":
+            # Send a shutdown command to the guest's shell
+            guest_session.sendline(guest_vm.get_params().get("shutdown_command"))
+            error.context("waiting VM to go down (shutdown shell cmd)")
+        elif params.get("shutdown_method") == "system_powerdown":
+            # Sleep for a while -- give the guest a chance to finish booting
+            time.sleep(float(params.get("sleep_before_powerdown", 10)))
+            # Send a system_powerdown monitor command
+            guest_vm.monitor.cmd("system_powerdown")
+            error.context("waiting VM to go down "
+                          "(system_powerdown monitor cmd)")
+
+        if not utils_misc.wait_for(guest_vm.is_dead, 240, 0, 1):
+            raise error.TestFail("Guest refuses to go down")
+
+    finally:
+        guest_session.close()

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -25,7 +25,7 @@ first_subtest = {'qemu': ['unattended_install'],
                 'openvswitch': ['unattended_install'],
                 'v2v': ['unattended_install']}
 
-last_subtest = {'qemu': ['shutdown'],
+last_subtest = {'qemu': ['shutdown', 'client_guest_shutdown'],
                 'libvirt': ['shutdown', 'remove_guest'],
                 'openvswitch': ['shutdown'],
                 'v2v': ['shutdown']}


### PR DESCRIPTION
Adding a shutdown test for spice tests that will shutdown both VMs, which are used for spice tests, since the default shutdown test only shutsdown 1 VM.
