### PR TITLE
Adding spice GUI tests

### DIFF
--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -10,6 +10,11 @@ wmctrl_32rpm = wmctrl-1.07-12.el6.i686.rpm
 test_dir = /root/autotest-beaker/virt-viewer-gui
 test_script_tgt = /home/test/tests
 
+#Version of remote-viewer
+rv_version = 0.5.2
+rv_version_el7 = 0.5.7-1
+
+
 # Use non-root user for Spice tests rather than root 
 # since User gnome session is needed.
 username=test
@@ -716,12 +721,6 @@ variants:
     - rv_gui_printscreen_accesskeys:
         rv_gui_test_list = printscreen_accesskeys
         only rv_gui_rhel6devel
-    - rv_gui_ctrl_alt_del:
-        rv_gui_test_list = ctrl_alt_del
-        only rv_gui_rhel6devel
-    - rv_gui_ctrl_alt_del_accesskeys:
-        rv_gui_test_list = ctrl_alt_del_accesskeys
-        only rv_gui_rhel6devel
     - rv_gui_windowresize_autoresize_on:
         changex = 700
         changey = 500
@@ -733,6 +732,12 @@ variants:
         changex = 800
         changey = 600
         accept_pct = 5
+        only rv_gui_rhel6devel
+    - rv_gui_ctrl_alt_del:
+        rv_gui_test_list = ctrl_alt_del
+        only rv_gui_rhel6devel
+    - rv_gui_ctrl_alt_del_accesskeys:
+        rv_gui_test_list = ctrl_alt_del_accesskeys
         only rv_gui_rhel6devel
     - audio_compression:
         audio_tgt = "~/tone.wav"
@@ -785,7 +790,7 @@ variants:
 only create_vms, negative_qemu_spice_launch_badport, negative_qemu_spice_launch_badic, negative_qemu_spice_launch_badjpegwc, negative_qemu_spice_launch_badzlib, negative_qemu_spice_launch_badsv, negative_qemu_spice_launch_badpc, remote_viewer_test, remote_viewer_ssl_test, remote_viewer_disconnect_test, guestvmshutdown_cmd, guestvmshutdown_qemu, copy_client_to_guest_largetext_pos, copy_guest_to_client_largetext_pos, copy_client_to_guest_pos, copy_guest_to_client_pos, copy_guest_to_client_neg, copy_client_to_guest_neg, copyimg_client_to_guest_pos, copyimg_client_to_guest_neg, copyimg_guest_to_client_pos, copyimg_guest_to_client_neg, copyimg_client_to_guest_dcp_neg, copyimg_guest_to_client_dcp_neg, copy_guest_to_client_dcp_neg, copy_client_to_guest_dcp_neg, copybmpimg_client_to_guest_pos, copybmpimg_guest_to_client_pos, copy_guest_to_client_largetext_10mb_pos, copy_client_to_guest_largetext_10mb_pos, copyimg_medium_client_to_guest_pos, copyimg_medium_guest_to_client_pos, copyimg_large_client_to_guest_pos, copyimg_large_guest_to_client_pos, restart_vdagent_copy_client_to_guest_pos, restart_vdagent_copy_guest_to_client_pos, restart_vdagent_copyimg_client_to_guest_pos, restart_vdagent_copyimg_guest_to_client_pos, restart_vdagent_copybmpimg_client_to_guest_pos, restart_vdagent_copybmpimg_guest_to_client_pos, restart_vdagent_copy_client_to_guest_largetext_pos, restart_vdagent_copy_guest_to_client_largetext_pos, remote_viewer_fullscreen_test, remote_viewer_fullscreen_test_neg, spice_vdagent_logging, qxl_logging, keyboard_input_leds_and_esc_keys, keyboard_input_non-us_layout, keyboard_input_type_and_func_keys, keyboard_input_leds_migration, rv_connect_passwd, rv_connect_wrong_passwd, rv_qemu_password, rv_qemu_password_overwrite, spice_migrate_simple, spice_migrate_ssl, spice_migrate_reboot, spice_migrate_video, spice_migrate_vdagent, rv_ssl_invalid_explicit_hs, rv_ssl_invalid_implicit_hs, rv_ssl_implicit_hs, rv_ssl_explicit_hs, rv_connect_menu, audio_compression, audio_no_compression, disable_audio, migrate_audio, remote_viewer_ipv6_addr, rv_qemu_report_ipv6, start_vdagent_test, stop_vdagent_test, restart_start_vdagent_test, restart_stop_vdagent_test, remote_viewer_smartcard_certdetail, remote_viewer_smartcard_certinfo
 
 #GUI tests, leaving commented out by default
-#only remote_viewer_setup, rv_gui_connect, rv_gui_quit_menu, rv_gui_quit_shortcut, rv_gui_quit_accesskeys, rv_gui_screenshot_default, rv_gui_screenshot_png, rv_gui_screenshot_bmp, rv_gui_screenshot_tiff, rv_gui_screenshot_invalid_text, rv_gui_zoomout, rv_gui_zoomout_shortcut, rv_gui_zoomout_accesskeys, rv_gui_zoomin, rv_gui_zoomin_shortcut, rv_gui_zoomin_accesskeys, rv_gui_zoomnorm, rv_gui_zoomnorm_shortcut, rv_gui_zoomnorm_accesskeys, rv_gui_help_about_version, rv_gui_help_about_license, rv_gui_help_about_credits, rv_gui_fullscreen_menu, rv_gui_fullscreen_shortcut, rv_gui_zoomnorm2, rv_gui_zoomnorm2_shortcut, rv_gui_windowed_switch_out_menu, rv_gui_windowed_switch_out_shortcut, rv_gui_fullscreen_switch_out_menu, rv_gui_fullscreen_switch_out_shortcut, rv_gui_ctrl_alt_del, rv_gui_ctrl_alt_del_accesskeys, rv_gui_printscreen, rv_gui_printscreen_accesskeys, rv_gui_windowresize_autoresize_off, rv_gui_windowresize_autoresize_on, rv_gui_close_display, rv_gui_close_shortcut, rv_gui_help_about_version_accesskeys, rv_gui_help_about_license_accesskeys, rv_gui_help_about_credits_accesskeys
+#only remote_viewer_setup, rv_gui_connect, rv_gui_quit_shortcut, rv_gui_quit_accesskeys, rv_gui_screenshot_default, rv_gui_screenshot_png, rv_gui_screenshot_bmp, rv_gui_screenshot_tiff, rv_gui_screenshot_invalid_text, rv_gui_zoomout, rv_gui_zoomout_shortcut, rv_gui_zoomout_accesskeys, rv_gui_zoomin, rv_gui_zoomin_shortcut, rv_gui_zoomin_accesskeys, rv_gui_zoomnorm, rv_gui_zoomnorm_shortcut, rv_gui_zoomnorm_accesskeys, rv_gui_help_about_version, rv_gui_help_about_license, rv_gui_help_about_credits, rv_gui_fullscreen_menu, rv_gui_fullscreen_shortcut, rv_gui_zoomnorm2, rv_gui_zoomnorm2_shortcut, rv_gui_windowed_switch_out_menu, rv_gui_windowed_switch_out_shortcut, rv_gui_fullscreen_switch_out_menu, rv_gui_fullscreen_switch_out_shortcut, rv_gui_ctrl_alt_del, rv_gui_ctrl_alt_del_accesskeys, rv_gui_printscreen, rv_gui_printscreen_accesskeys, rv_gui_windowresize_autoresize_off, rv_gui_windowresize_autoresize_on, rv_gui_close_display, rv_gui_close_shortcut, rv_gui_help_about_version_accesskeys, rv_gui_help_about_license_accesskeys, rv_gui_help_about_credits_accesskeys
 
 #Running all RHEL Client, Windows Guest Spice Tests
 #only install_win_guest, remote_viewer_winguest_test

--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -3,7 +3,10 @@ include tests-shared.cfg
 image_size = 20G
 spice_seamless_migration = on
 drive_cache=none
-dogtail_rpm = 'http://dl.fedoraproject.org/pub/epel/6/x86_64/dogtail-0.7.1.1-1.el6.noarch.rpm'
+dogtail_rpm = 'dogtail-0.7.1.1-1.el6.noarch.rpm'
+fedoraurl = 'http://dl.fedoraproject.org/pub/epel/6'
+wmctrl_64rpm = wmctrl-1.07-12.el6.x86_64.rpm
+wmctrl_32rpm = wmctrl-1.07-12.el6.i686.rpm
 test_dir = /root/autotest-beaker/virt-viewer-gui
 test_script_tgt = /home/test/tests
 
@@ -691,6 +694,18 @@ variants:
     - rv_gui_ctrl_alt_del_accesskeys:
         rv_gui_test_list = ctrl_alt_del_accesskeys
         only rv_gui_rhel6devel
+    - rv_gui_windowresize_autoresize_on:
+        changex = 700
+        changey = 1100
+        accept_pct = 5
+        rv_gui_test_list = autoresize_on
+        only rv_gui_rhel6devel
+    - rv_gui_windowresize_autoresize_off:
+        rv_gui_test_list = autoresize_off
+        changex = 800
+        changey = 600
+        accept_pct = 5
+        only rv_gui_rhel6devel
     - audio_compression:
         audio_tgt = "~/tone.wav"
         audio_rec = "~/rec.wav"
@@ -742,7 +757,7 @@ variants:
 only create_vms, negative_qemu_spice_launch_badport, negative_qemu_spice_launch_badic, negative_qemu_spice_launch_badjpegwc, negative_qemu_spice_launch_badzlib, negative_qemu_spice_launch_badsv, negative_qemu_spice_launch_badpc, remote_viewer_test, remote_viewer_ssl_test, remote_viewer_disconnect_test, guestvmshutdown_cmd, guestvmshutdown_qemu, copy_client_to_guest_largetext_pos, copy_guest_to_client_largetext_pos, copy_client_to_guest_pos, copy_guest_to_client_pos, copy_guest_to_client_neg, copy_client_to_guest_neg, copyimg_client_to_guest_pos, copyimg_client_to_guest_neg, copyimg_guest_to_client_pos, copyimg_guest_to_client_neg, copyimg_client_to_guest_dcp_neg, copyimg_guest_to_client_dcp_neg, copy_guest_to_client_dcp_neg, copy_client_to_guest_dcp_neg, copybmpimg_client_to_guest_pos, copybmpimg_guest_to_client_pos, copy_guest_to_client_largetext_10mb_pos, copy_client_to_guest_largetext_10mb_pos, copyimg_medium_client_to_guest_pos, copyimg_medium_guest_to_client_pos, copyimg_large_client_to_guest_pos, copyimg_large_guest_to_client_pos, restart_vdagent_copy_client_to_guest_pos, restart_vdagent_copy_guest_to_client_pos, restart_vdagent_copyimg_client_to_guest_pos, restart_vdagent_copyimg_guest_to_client_pos, restart_vdagent_copybmpimg_client_to_guest_pos, restart_vdagent_copybmpimg_guest_to_client_pos, restart_vdagent_copy_client_to_guest_largetext_pos, restart_vdagent_copy_guest_to_client_largetext_pos, remote_viewer_fullscreen_test, remote_viewer_fullscreen_test_neg, spice_vdagent_logging, qxl_logging, keyboard_input_leds_and_esc_keys, keyboard_input_non-us_layout, keyboard_input_type_and_func_keys, keyboard_input_leds_migration, rv_connect_passwd, rv_connect_wrong_passwd, rv_qemu_password, rv_qemu_password_overwrite, spice_migrate_simple, spice_migrate_ssl, spice_migrate_reboot, spice_migrate_video, spice_migrate_vdagent, rv_ssl_invalid_explicit_hs, rv_ssl_invalid_implicit_hs, rv_ssl_implicit_hs, rv_ssl_explicit_hs, rv_connect_menu, audio_compression, audio_no_compression, disable_audio, migrate_audio, remote_viewer_ipv6_addr, rv_qemu_report_ipv6, start_vdagent_test, stop_vdagent_test, restart_start_vdagent_test, restart_stop_vdagent_test, remote_viewer_smartcard_certdetail, remote_viewer_smartcard_certinfo
 
 #GUI tests, leaving commented out by default
-#only remote_viewer_setup, rv_gui_connect, rv_gui_quit_menu, rv_gui_quit_shortcut, rv_gui_screenshot_default, rv_gui_screenshot_png, rv_gui_screenshot_bmp, rv_gui_screenshot_tiff, rv_gui_screenshot_invalid_text, rv_gui_zoomout, rv_gui_zoomout_shortcut, rv_gui_zoomin, rv_gui_zoomin_shortcut, rv_gui_zoomnorm, rv_gui_zoomnorm_shortcut, rv_gui_help_about_version, rv_gui_help_about_license, rv_gui_help_about_credits, rv_gui_quit_menu, rv_gui_quit_shortcut, rv_gui_fullscreen_menu, rv_gui_fullscreen_shortcut, rv_gui_zoomnorm2, rv_gui_zoomnorm2_shortcut, rv_gui_windowed_switch_out_menu, rv_gui_windowed_switch_out_shortcut, rv_gui_fullscreen_switch_out_menu, rv_gui_fullscreen_switch_out_shortcut, rv_gui_ctrl_alt_del, rv_gui_ctrl_alt_del_accesskeys, rv_gui_printscreen, rv_gui_printscreen_accesskeys
+#only remote_viewer_setup, rv_gui_connect, rv_gui_quit_menu, rv_gui_quit_shortcut, rv_gui_screenshot_default, rv_gui_screenshot_png, rv_gui_screenshot_bmp, rv_gui_screenshot_tiff, rv_gui_screenshot_invalid_text, rv_gui_zoomout, rv_gui_zoomout_shortcut, rv_gui_zoomin, rv_gui_zoomin_shortcut, rv_gui_zoomnorm, rv_gui_zoomnorm_shortcut, rv_gui_help_about_version, rv_gui_help_about_license, rv_gui_help_about_credits, rv_gui_quit_menu, rv_gui_quit_shortcut, rv_gui_fullscreen_menu, rv_gui_fullscreen_shortcut, rv_gui_zoomnorm2, rv_gui_zoomnorm2_shortcut, rv_gui_windowed_switch_out_menu, rv_gui_windowed_switch_out_shortcut, rv_gui_fullscreen_switch_out_menu, rv_gui_fullscreen_switch_out_shortcut, rv_gui_ctrl_alt_del, rv_gui_ctrl_alt_del_accesskeys, rv_gui_printscreen, rv_gui_printscreen_accesskeys, rv_gui_windowresize_autoresize_off, rv_gui_windowresize_autoresize_on
 
 #Running all RHEL Client, Windows Guest Spice Tests
 #only install_win_guest, remote_viewer_winguest_test

--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -337,14 +337,13 @@ variants:
         spice_port=3000
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-        only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_gui.RHEL.6.devel.x86_64, rv.rr.rv_clearx.RHEL.6.devel.x86_64
+        only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_gui.RHEL.6.devel.x86_64
 
     - @rv_gui_fullscreen_rhel6devel:
         spice_port=3000
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
-        only rv.rr.fullscreen_setup.RHEL.6.devel.x86_64, rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_gui.RHEL.6.devel.x86_64, rv.rr.rv_clearx.RHEL.6.devel.x86_64
-
+        only rv.rr.fullscreen_setup.RHEL.6.devel.x86_64, rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_gui.RHEL.6.devel.x86_64
 
     - @rv_vmshutdown_rhel6devel:
         only os.RHEL

--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -607,26 +607,44 @@ variants:
     - rv_gui_zoomout_shortcut:
         rv_gui_test_list = zoomout_shortcut
         only rv_gui_rhel6devel
+    - rv_gui_zoomout_accesskeys:
+        rv_gui_test_list = zoomout_accesskeys
+        only rv_gui_rhel6devel
     - rv_gui_zoomin:
         rv_gui_test_list = zoomin
         only rv_gui_rhel6devel
     - rv_gui_zoomin_shortcut:
         rv_gui_test_list = zoomin_shortcut
         only rv_gui_rhel6devel
+    - rv_gui_zoomin_accesskeys:
+        rv_gui_test_list = zoomin_accesskeys
+        only rv_gui_rhel6devel
     - rv_gui_help_about_version:
         rv_gui_test_list = help
+        only rv_gui_rhel6devel
+    - rv_gui_help_about_version_accesskeys:
+        rv_gui_test_list = help_accesskeys
         only rv_gui_rhel6devel
     - rv_gui_help_about_license:
         rv_gui_test_list = help_license
         only rv_gui_rhel6devel
+    - rv_gui_help_about_license_accesskeys:
+        rv_gui_test_list = help_license_accesskeys
+        only rv_gui_rhel6devel
     - rv_gui_help_about_credits:
         rv_gui_test_list = help_credits
+        only rv_gui_rhel6devel
+    - rv_gui_help_about_credits_accesskeys:
+        rv_gui_test_list = help_credits_accesskeys
         only rv_gui_rhel6devel
     - rv_gui_quit_menu:
         rv_gui_test_list = quit_menu
         only rv_gui_rhel6devel
     - rv_gui_quit_shortcut:
         rv_gui_test_list = quit_shortcut
+        only rv_gui_rhel6devel
+    - rv_gui_quit_accesskeys:
+        rv_gui_test_list = quit_accesskeys
         only rv_gui_rhel6devel
     - rv_gui_close_display:
         rv_gui_test_list = close
@@ -645,6 +663,9 @@ variants:
         only rv_gui_rhel6devel
     - rv_gui_zoomnorm2_shortcut:
         rv_gui_test_list = zoomout zoomout zoomout zoomnorm_shortcut
+        only rv_gui_rhel6devel
+    - rv_gui_zoomnorm_accesskeys:
+        rv_gui_test_list = zoomin_accesskeys zoomin_accesskeys zoomnorm_accesskeys
         only rv_gui_rhel6devel
     - rv_gui_screenshot_default:
         rv_gui_test_list = screenshot
@@ -703,7 +724,7 @@ variants:
         only rv_gui_rhel6devel
     - rv_gui_windowresize_autoresize_on:
         changex = 700
-        changey = 1100
+        changey = 500
         accept_pct = 5
         rv_gui_test_list = autoresize_on
         only rv_gui_rhel6devel
@@ -764,7 +785,7 @@ variants:
 only create_vms, negative_qemu_spice_launch_badport, negative_qemu_spice_launch_badic, negative_qemu_spice_launch_badjpegwc, negative_qemu_spice_launch_badzlib, negative_qemu_spice_launch_badsv, negative_qemu_spice_launch_badpc, remote_viewer_test, remote_viewer_ssl_test, remote_viewer_disconnect_test, guestvmshutdown_cmd, guestvmshutdown_qemu, copy_client_to_guest_largetext_pos, copy_guest_to_client_largetext_pos, copy_client_to_guest_pos, copy_guest_to_client_pos, copy_guest_to_client_neg, copy_client_to_guest_neg, copyimg_client_to_guest_pos, copyimg_client_to_guest_neg, copyimg_guest_to_client_pos, copyimg_guest_to_client_neg, copyimg_client_to_guest_dcp_neg, copyimg_guest_to_client_dcp_neg, copy_guest_to_client_dcp_neg, copy_client_to_guest_dcp_neg, copybmpimg_client_to_guest_pos, copybmpimg_guest_to_client_pos, copy_guest_to_client_largetext_10mb_pos, copy_client_to_guest_largetext_10mb_pos, copyimg_medium_client_to_guest_pos, copyimg_medium_guest_to_client_pos, copyimg_large_client_to_guest_pos, copyimg_large_guest_to_client_pos, restart_vdagent_copy_client_to_guest_pos, restart_vdagent_copy_guest_to_client_pos, restart_vdagent_copyimg_client_to_guest_pos, restart_vdagent_copyimg_guest_to_client_pos, restart_vdagent_copybmpimg_client_to_guest_pos, restart_vdagent_copybmpimg_guest_to_client_pos, restart_vdagent_copy_client_to_guest_largetext_pos, restart_vdagent_copy_guest_to_client_largetext_pos, remote_viewer_fullscreen_test, remote_viewer_fullscreen_test_neg, spice_vdagent_logging, qxl_logging, keyboard_input_leds_and_esc_keys, keyboard_input_non-us_layout, keyboard_input_type_and_func_keys, keyboard_input_leds_migration, rv_connect_passwd, rv_connect_wrong_passwd, rv_qemu_password, rv_qemu_password_overwrite, spice_migrate_simple, spice_migrate_ssl, spice_migrate_reboot, spice_migrate_video, spice_migrate_vdagent, rv_ssl_invalid_explicit_hs, rv_ssl_invalid_implicit_hs, rv_ssl_implicit_hs, rv_ssl_explicit_hs, rv_connect_menu, audio_compression, audio_no_compression, disable_audio, migrate_audio, remote_viewer_ipv6_addr, rv_qemu_report_ipv6, start_vdagent_test, stop_vdagent_test, restart_start_vdagent_test, restart_stop_vdagent_test, remote_viewer_smartcard_certdetail, remote_viewer_smartcard_certinfo
 
 #GUI tests, leaving commented out by default
-#only remote_viewer_setup, rv_gui_connect, rv_gui_quit_menu, rv_gui_quit_shortcut, rv_gui_screenshot_default, rv_gui_screenshot_png, rv_gui_screenshot_bmp, rv_gui_screenshot_tiff, rv_gui_screenshot_invalid_text, rv_gui_zoomout, rv_gui_zoomout_shortcut, rv_gui_zoomin, rv_gui_zoomin_shortcut, rv_gui_zoomnorm, rv_gui_zoomnorm_shortcut, rv_gui_help_about_version, rv_gui_help_about_license, rv_gui_help_about_credits, rv_gui_fullscreen_menu, rv_gui_fullscreen_shortcut, rv_gui_zoomnorm2, rv_gui_zoomnorm2_shortcut, rv_gui_windowed_switch_out_menu, rv_gui_windowed_switch_out_shortcut, rv_gui_fullscreen_switch_out_menu, rv_gui_fullscreen_switch_out_shortcut, rv_gui_ctrl_alt_del, rv_gui_ctrl_alt_del_accesskeys, rv_gui_printscreen, rv_gui_printscreen_accesskeys, rv_gui_windowresize_autoresize_off, rv_gui_windowresize_autoresize_on, rv_gui_close_display, rv_gui_close_shortcut
+#only remote_viewer_setup, rv_gui_connect, rv_gui_quit_menu, rv_gui_quit_shortcut, rv_gui_quit_accesskeys, rv_gui_screenshot_default, rv_gui_screenshot_png, rv_gui_screenshot_bmp, rv_gui_screenshot_tiff, rv_gui_screenshot_invalid_text, rv_gui_zoomout, rv_gui_zoomout_shortcut, rv_gui_zoomout_accesskeys, rv_gui_zoomin, rv_gui_zoomin_shortcut, rv_gui_zoomin_accesskeys, rv_gui_zoomnorm, rv_gui_zoomnorm_shortcut, rv_gui_zoomnorm_accesskeys, rv_gui_help_about_version, rv_gui_help_about_license, rv_gui_help_about_credits, rv_gui_fullscreen_menu, rv_gui_fullscreen_shortcut, rv_gui_zoomnorm2, rv_gui_zoomnorm2_shortcut, rv_gui_windowed_switch_out_menu, rv_gui_windowed_switch_out_shortcut, rv_gui_fullscreen_switch_out_menu, rv_gui_fullscreen_switch_out_shortcut, rv_gui_ctrl_alt_del, rv_gui_ctrl_alt_del_accesskeys, rv_gui_printscreen, rv_gui_printscreen_accesskeys, rv_gui_windowresize_autoresize_off, rv_gui_windowresize_autoresize_on, rv_gui_close_display, rv_gui_close_shortcut, rv_gui_help_about_version_accesskeys, rv_gui_help_about_license_accesskeys, rv_gui_help_about_credits_accesskeys
 
 #Running all RHEL Client, Windows Guest Spice Tests
 #only install_win_guest, remote_viewer_winguest_test

--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -600,6 +600,7 @@ variants:
         full_screen = yes
         config_test = "leds_migration"
         only rv_input_rhel6devel
+    #Before running any of the rv_gui tests, rv_setup must be run
     - rv_gui_zoomout:
         rv_gui_test_list = zoomout
         only rv_gui_rhel6devel
@@ -626,6 +627,12 @@ variants:
         only rv_gui_rhel6devel
     - rv_gui_quit_shortcut:
         rv_gui_test_list = quit_shortcut
+        only rv_gui_rhel6devel
+    - rv_gui_close_display:
+        rv_gui_test_list = close
+        only rv_gui_rhel6devel
+    - rv_gui_close_shortcut:
+        rv_gui_test_list = close_shortcut
         only rv_gui_rhel6devel
     - rv_gui_zoomnorm:
         rv_gui_test_list = zoomin zoomin zoomnorm
@@ -757,7 +764,7 @@ variants:
 only create_vms, negative_qemu_spice_launch_badport, negative_qemu_spice_launch_badic, negative_qemu_spice_launch_badjpegwc, negative_qemu_spice_launch_badzlib, negative_qemu_spice_launch_badsv, negative_qemu_spice_launch_badpc, remote_viewer_test, remote_viewer_ssl_test, remote_viewer_disconnect_test, guestvmshutdown_cmd, guestvmshutdown_qemu, copy_client_to_guest_largetext_pos, copy_guest_to_client_largetext_pos, copy_client_to_guest_pos, copy_guest_to_client_pos, copy_guest_to_client_neg, copy_client_to_guest_neg, copyimg_client_to_guest_pos, copyimg_client_to_guest_neg, copyimg_guest_to_client_pos, copyimg_guest_to_client_neg, copyimg_client_to_guest_dcp_neg, copyimg_guest_to_client_dcp_neg, copy_guest_to_client_dcp_neg, copy_client_to_guest_dcp_neg, copybmpimg_client_to_guest_pos, copybmpimg_guest_to_client_pos, copy_guest_to_client_largetext_10mb_pos, copy_client_to_guest_largetext_10mb_pos, copyimg_medium_client_to_guest_pos, copyimg_medium_guest_to_client_pos, copyimg_large_client_to_guest_pos, copyimg_large_guest_to_client_pos, restart_vdagent_copy_client_to_guest_pos, restart_vdagent_copy_guest_to_client_pos, restart_vdagent_copyimg_client_to_guest_pos, restart_vdagent_copyimg_guest_to_client_pos, restart_vdagent_copybmpimg_client_to_guest_pos, restart_vdagent_copybmpimg_guest_to_client_pos, restart_vdagent_copy_client_to_guest_largetext_pos, restart_vdagent_copy_guest_to_client_largetext_pos, remote_viewer_fullscreen_test, remote_viewer_fullscreen_test_neg, spice_vdagent_logging, qxl_logging, keyboard_input_leds_and_esc_keys, keyboard_input_non-us_layout, keyboard_input_type_and_func_keys, keyboard_input_leds_migration, rv_connect_passwd, rv_connect_wrong_passwd, rv_qemu_password, rv_qemu_password_overwrite, spice_migrate_simple, spice_migrate_ssl, spice_migrate_reboot, spice_migrate_video, spice_migrate_vdagent, rv_ssl_invalid_explicit_hs, rv_ssl_invalid_implicit_hs, rv_ssl_implicit_hs, rv_ssl_explicit_hs, rv_connect_menu, audio_compression, audio_no_compression, disable_audio, migrate_audio, remote_viewer_ipv6_addr, rv_qemu_report_ipv6, start_vdagent_test, stop_vdagent_test, restart_start_vdagent_test, restart_stop_vdagent_test, remote_viewer_smartcard_certdetail, remote_viewer_smartcard_certinfo
 
 #GUI tests, leaving commented out by default
-#only remote_viewer_setup, rv_gui_connect, rv_gui_quit_menu, rv_gui_quit_shortcut, rv_gui_screenshot_default, rv_gui_screenshot_png, rv_gui_screenshot_bmp, rv_gui_screenshot_tiff, rv_gui_screenshot_invalid_text, rv_gui_zoomout, rv_gui_zoomout_shortcut, rv_gui_zoomin, rv_gui_zoomin_shortcut, rv_gui_zoomnorm, rv_gui_zoomnorm_shortcut, rv_gui_help_about_version, rv_gui_help_about_license, rv_gui_help_about_credits, rv_gui_quit_menu, rv_gui_quit_shortcut, rv_gui_fullscreen_menu, rv_gui_fullscreen_shortcut, rv_gui_zoomnorm2, rv_gui_zoomnorm2_shortcut, rv_gui_windowed_switch_out_menu, rv_gui_windowed_switch_out_shortcut, rv_gui_fullscreen_switch_out_menu, rv_gui_fullscreen_switch_out_shortcut, rv_gui_ctrl_alt_del, rv_gui_ctrl_alt_del_accesskeys, rv_gui_printscreen, rv_gui_printscreen_accesskeys, rv_gui_windowresize_autoresize_off, rv_gui_windowresize_autoresize_on
+#only remote_viewer_setup, rv_gui_connect, rv_gui_quit_menu, rv_gui_quit_shortcut, rv_gui_screenshot_default, rv_gui_screenshot_png, rv_gui_screenshot_bmp, rv_gui_screenshot_tiff, rv_gui_screenshot_invalid_text, rv_gui_zoomout, rv_gui_zoomout_shortcut, rv_gui_zoomin, rv_gui_zoomin_shortcut, rv_gui_zoomnorm, rv_gui_zoomnorm_shortcut, rv_gui_help_about_version, rv_gui_help_about_license, rv_gui_help_about_credits, rv_gui_fullscreen_menu, rv_gui_fullscreen_shortcut, rv_gui_zoomnorm2, rv_gui_zoomnorm2_shortcut, rv_gui_windowed_switch_out_menu, rv_gui_windowed_switch_out_shortcut, rv_gui_fullscreen_switch_out_menu, rv_gui_fullscreen_switch_out_shortcut, rv_gui_ctrl_alt_del, rv_gui_ctrl_alt_del_accesskeys, rv_gui_printscreen, rv_gui_printscreen_accesskeys, rv_gui_windowresize_autoresize_off, rv_gui_windowresize_autoresize_on, rv_gui_close_display, rv_gui_close_shortcut
 
 #Running all RHEL Client, Windows Guest Spice Tests
 #only install_win_guest, remote_viewer_winguest_test

--- a/qemu/cfg/tests-spice.cfg
+++ b/qemu/cfg/tests-spice.cfg
@@ -3,6 +3,9 @@ include tests-shared.cfg
 image_size = 20G
 spice_seamless_migration = on
 drive_cache=none
+dogtail_rpm = 'http://dl.fedoraproject.org/pub/epel/6/x86_64/dogtail-0.7.1.1-1.el6.noarch.rpm'
+test_dir = /root/autotest-beaker/virt-viewer-gui
+test_script_tgt = /home/test/tests
 
 # Use non-root user for Spice tests rather than root 
 # since User gnome session is needed.
@@ -221,6 +224,11 @@ variants:
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
         only unattended_install.cdrom.extra_cdrom_ks
 
+    - @remote_viewer_setup:
+        only os.RHEL
+        only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
+        only rv.rr.rv_setup.RHEL.6.devel.x86_64
+
     - @remote_viewer_rhel6develssl:
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.ssl.key_password.password.dcp_off.1monitor.default_sc
@@ -324,6 +332,20 @@ variants:
                 only spice.default_ipv.no_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
                 only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_audio.RHEL.6.devel.x86_64, rv.rr.rv_clearx.RHEL.6.devel.x86_64
 
+    - @rv_gui_rhel6devel:
+        screenshot_dir=/home/test/Pictures
+        spice_port=3000
+        only os.RHEL
+        only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
+        only rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_gui.RHEL.6.devel.x86_64, rv.rr.rv_clearx.RHEL.6.devel.x86_64
+
+    - @rv_gui_fullscreen_rhel6devel:
+        spice_port=3000
+        only os.RHEL
+        only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
+        only rv.rr.fullscreen_setup.RHEL.6.devel.x86_64, rv.rr.rv_connect.RHEL.6.devel.x86_64, rv.rr.rv_gui.RHEL.6.devel.x86_64, rv.rr.rv_clearx.RHEL.6.devel.x86_64
+
+
     - @rv_vmshutdown_rhel6devel:
         only os.RHEL
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.no_ssl.no_password.dcp_off.1monitor.default_sc
@@ -335,6 +357,8 @@ variants:
         only qemu_kvm_rhel6devel_install_guest, qemu_kvm_rhel6devel_install_client
     - install_win_guest:
         only qemu_kvm_windows_install_guest
+    - remote_viewer_test_setup:
+        only remote_viewer_setup
     - negative_qemu_spice_launch_badport:
         only spice.default_ipv.default_pc.default_sv.default_zlib_wc.default_jpeg_wc.default_ic.bad_port.no_password.dcp_off.1monitor.default_sc
         only spice_negative_rhel6devel
@@ -574,6 +598,100 @@ variants:
         full_screen = yes
         config_test = "leds_migration"
         only rv_input_rhel6devel
+    - rv_gui_zoomout:
+        rv_gui_test_list = zoomout
+        only rv_gui_rhel6devel
+    - rv_gui_zoomout_shortcut:
+        rv_gui_test_list = zoomout_shortcut
+        only rv_gui_rhel6devel
+    - rv_gui_zoomin:
+        rv_gui_test_list = zoomin
+        only rv_gui_rhel6devel
+    - rv_gui_zoomin_shortcut:
+        rv_gui_test_list = zoomin_shortcut
+        only rv_gui_rhel6devel
+    - rv_gui_help_about_version:
+        rv_gui_test_list = help
+        only rv_gui_rhel6devel
+    - rv_gui_help_about_license:
+        rv_gui_test_list = help_license
+        only rv_gui_rhel6devel
+    - rv_gui_help_about_credits:
+        rv_gui_test_list = help_credits
+        only rv_gui_rhel6devel
+    - rv_gui_quit_menu:
+        rv_gui_test_list = quit_menu
+        only rv_gui_rhel6devel
+    - rv_gui_quit_shortcut:
+        rv_gui_test_list = quit_shortcut
+        only rv_gui_rhel6devel
+    - rv_gui_zoomnorm:
+        rv_gui_test_list = zoomin zoomin zoomnorm
+        only rv_gui_rhel6devel
+    - rv_gui_zoomnorm_shortcut:
+        rv_gui_test_list = zoomin zoomin zoomnorm_shortcut
+        only rv_gui_rhel6devel
+    - rv_gui_zoomnorm2:
+        rv_gui_test_list = zoomout zoomout zoomout zoomnorm
+        only rv_gui_rhel6devel
+    - rv_gui_zoomnorm2_shortcut:
+        rv_gui_test_list = zoomout zoomout zoomout zoomnorm_shortcut
+        only rv_gui_rhel6devel
+    - rv_gui_screenshot_default:
+        rv_gui_test_list = screenshot
+        screenshot_expected_name = "Screenshot.png"
+        only rv_gui_rhel6devel
+    - rv_gui_screenshot_png:
+        rv_gui_test_list = screenshot_cname_png
+        screenshot_expected_name = "custom_name.png"
+        only rv_gui_rhel6devel
+    - rv_gui_screenshot_bmp:
+        rv_gui_test_list = screenshot_cname_bmp
+        screenshot_expected_name = "custom_name.bmp"
+        only rv_gui_rhel6devel
+    - rv_gui_screenshot_tiff:
+        rv_gui_test_list = screenshot_cname_tiff
+        screenshot_expected_name = "custom_name.tiff"
+        only rv_gui_rhel6devel
+    - rv_gui_screenshot_invalid_text:
+        rv_gui_test_list = screenshot_cname_invalidtext
+        screenshot_expected_name = "custom_name.abcd.png"
+        only rv_gui_rhel6devel
+    - rv_gui_fullscreen_menu:
+        rv_gui_test_list = fullscreen
+        only rv_gui_fullscreen_rhel6devel
+    - rv_gui_fullscreen_shortcut:
+        rv_gui_test_list = fullscreen_shortcut
+        only rv_gui_fullscreen_rhel6devel
+    - rv_gui_fullscreen_switch_out_menu:
+        full_screen = yes
+        rv_gui_test_list = leave_fullscreen fullscreen
+        only rv_gui_fullscreen_rhel6devel
+    - rv_gui_fullscreen_switch_out_shortcut:
+        full_screen = yes
+        rv_gui_test_list = leave_fullscreen_shortcut fullscreen_shortcut
+        only rv_gui_fullscreen_rhel6devel
+    - rv_gui_windowed_switch_out_menu:
+        rv_gui_test_list = fullscreen leave_fullscreen
+        only rv_gui_fullscreen_rhel6devel
+    - rv_gui_windowed_switch_out_shortcut:
+        rv_gui_test_list = fullscreen_shortcut leave_fullscreen_shortcut
+        only rv_gui_fullscreen_rhel6devel
+    - rv_gui_connect:
+        rv_gui_test_list = connect
+        only rv_gui_rhel6devel
+    - rv_gui_printscreen:
+        rv_gui_test_list = printscreen
+        only rv_gui_rhel6devel
+    - rv_gui_printscreen_accesskeys:
+        rv_gui_test_list = printscreen_accesskeys
+        only rv_gui_rhel6devel
+    - rv_gui_ctrl_alt_del:
+        rv_gui_test_list = ctrl_alt_del
+        only rv_gui_rhel6devel
+    - rv_gui_ctrl_alt_del_accesskeys:
+        rv_gui_test_list = ctrl_alt_del_accesskeys
+        only rv_gui_rhel6devel
     - audio_compression:
         audio_tgt = "~/tone.wav"
         audio_rec = "~/rec.wav"
@@ -623,6 +741,9 @@ variants:
 
 #Running all RHEL Client, RHEL Guest Spice Tests
 only create_vms, negative_qemu_spice_launch_badport, negative_qemu_spice_launch_badic, negative_qemu_spice_launch_badjpegwc, negative_qemu_spice_launch_badzlib, negative_qemu_spice_launch_badsv, negative_qemu_spice_launch_badpc, remote_viewer_test, remote_viewer_ssl_test, remote_viewer_disconnect_test, guestvmshutdown_cmd, guestvmshutdown_qemu, copy_client_to_guest_largetext_pos, copy_guest_to_client_largetext_pos, copy_client_to_guest_pos, copy_guest_to_client_pos, copy_guest_to_client_neg, copy_client_to_guest_neg, copyimg_client_to_guest_pos, copyimg_client_to_guest_neg, copyimg_guest_to_client_pos, copyimg_guest_to_client_neg, copyimg_client_to_guest_dcp_neg, copyimg_guest_to_client_dcp_neg, copy_guest_to_client_dcp_neg, copy_client_to_guest_dcp_neg, copybmpimg_client_to_guest_pos, copybmpimg_guest_to_client_pos, copy_guest_to_client_largetext_10mb_pos, copy_client_to_guest_largetext_10mb_pos, copyimg_medium_client_to_guest_pos, copyimg_medium_guest_to_client_pos, copyimg_large_client_to_guest_pos, copyimg_large_guest_to_client_pos, restart_vdagent_copy_client_to_guest_pos, restart_vdagent_copy_guest_to_client_pos, restart_vdagent_copyimg_client_to_guest_pos, restart_vdagent_copyimg_guest_to_client_pos, restart_vdagent_copybmpimg_client_to_guest_pos, restart_vdagent_copybmpimg_guest_to_client_pos, restart_vdagent_copy_client_to_guest_largetext_pos, restart_vdagent_copy_guest_to_client_largetext_pos, remote_viewer_fullscreen_test, remote_viewer_fullscreen_test_neg, spice_vdagent_logging, qxl_logging, keyboard_input_leds_and_esc_keys, keyboard_input_non-us_layout, keyboard_input_type_and_func_keys, keyboard_input_leds_migration, rv_connect_passwd, rv_connect_wrong_passwd, rv_qemu_password, rv_qemu_password_overwrite, spice_migrate_simple, spice_migrate_ssl, spice_migrate_reboot, spice_migrate_video, spice_migrate_vdagent, rv_ssl_invalid_explicit_hs, rv_ssl_invalid_implicit_hs, rv_ssl_implicit_hs, rv_ssl_explicit_hs, rv_connect_menu, audio_compression, audio_no_compression, disable_audio, migrate_audio, remote_viewer_ipv6_addr, rv_qemu_report_ipv6, start_vdagent_test, stop_vdagent_test, restart_start_vdagent_test, restart_stop_vdagent_test, remote_viewer_smartcard_certdetail, remote_viewer_smartcard_certinfo
+
+#GUI tests, leaving commented out by default
+#only remote_viewer_setup, rv_gui_connect, rv_gui_quit_menu, rv_gui_quit_shortcut, rv_gui_screenshot_default, rv_gui_screenshot_png, rv_gui_screenshot_bmp, rv_gui_screenshot_tiff, rv_gui_screenshot_invalid_text, rv_gui_zoomout, rv_gui_zoomout_shortcut, rv_gui_zoomin, rv_gui_zoomin_shortcut, rv_gui_zoomnorm, rv_gui_zoomnorm_shortcut, rv_gui_help_about_version, rv_gui_help_about_license, rv_gui_help_about_credits, rv_gui_quit_menu, rv_gui_quit_shortcut, rv_gui_fullscreen_menu, rv_gui_fullscreen_shortcut, rv_gui_zoomnorm2, rv_gui_zoomnorm2_shortcut, rv_gui_windowed_switch_out_menu, rv_gui_windowed_switch_out_shortcut, rv_gui_fullscreen_switch_out_menu, rv_gui_fullscreen_switch_out_shortcut, rv_gui_ctrl_alt_del, rv_gui_ctrl_alt_del_accesskeys, rv_gui_printscreen, rv_gui_printscreen_accesskeys
 
 #Running all RHEL Client, Windows Guest Spice Tests
 #only install_win_guest, remote_viewer_winguest_test

--- a/qemu/tests/cfg/spice.cfg
+++ b/qemu/tests/cfg/spice.cfg
@@ -21,6 +21,8 @@
         -RHEL.6.devel.i386:
             image_name_vm2 = images/rhel6devel-32_client
     variants:
+        - rv_setup:
+            type = rv_setup
         - fullscreen_setup:
             type = fullscreen_setup
         - smartcard_setup:
@@ -94,6 +96,8 @@
             vdagent_test = start
         - rv_smartcard: rv_connect
             type = rv_smartcard
+        - rv_gui:
+            type = rv_gui
         - rv_disconnect: rv_connect
             type = kill_app
         - rv_vmshutdown: rv_connect

--- a/qemu/tests/cfg/spice.cfg
+++ b/qemu/tests/cfg/spice.cfg
@@ -118,7 +118,7 @@
         -rr:
         #variant for a RHEL client and a Windows guest
         -rw:
-            pssword = 1q2w3eP
+            password = 1q2w3eP
             password_vm2 = 123456
             display_vm2 = vnc
             os_type_vm2 = linux

--- a/shared/unattended/RHEL-6.3.ks
+++ b/shared/unattended/RHEL-6.3.ks
@@ -31,6 +31,7 @@ KVM_TEST_LOGGING
 @basic-desktop
 @fonts
 @Smart Card Support
+gnome-utils
 NetworkManager
 ntpdate
 watchdog

--- a/tests/fullscreen_setup.py
+++ b/tests/fullscreen_setup.py
@@ -28,6 +28,7 @@ def run_fullscreen_setup(test, params, env):
     guest_vm.verify_alive()
     guest_session = guest_vm.wait_for_login(
             timeout=int(params.get("login_timeout", 360)))
+    guest_root_session = guest_vm.wait_for_login(username="root", password="123456")
 
     utils_spice.wait_timeout(10)
 
@@ -61,7 +62,7 @@ def run_fullscreen_setup(test, params, env):
                  current + " to: " + resolution)
 
     # Start vdagent daemon
-    utils_spice.start_vdagent(guest_session, test_timeout)
+    utils_spice.start_vdagent(guest_root_session, test_timeout)
 
     client_vm = env.get_vm(params["client_vm"])
     client_vm.verify_alive()

--- a/tests/rv_connect.py
+++ b/tests/rv_connect.py
@@ -280,8 +280,22 @@ def run_rv_connect(test, params, env):
     client_vm.verify_alive()
     client_session = client_vm.wait_for_login(
             timeout=int(params.get("login_timeout", 360)))
+    guest_root_session = guest_vm.wait_for_login(username = "root",
+      password = "123456", timeout=int(params.get("login_timeout", 360)))
+    client_root_session = client_vm.wait_for_login(username = "root",
+      password = "123456", timeout=int(params.get("login_timeout", 360)))
+
 
     utils_spice.wait_timeout(15)
+
+    logging.info("Restarting GDM session on client")
+    client_root_session.cmd("killall gdm-binary")
+
+    logging.info("Restarting GDM session on guest")
+    guest_root_session.cmd("killall gdm-binary")
+
+    #Wait after gdm is restarted before attempting a rv connection.
+    utils_spice.wait_timeout(3)
 
     launch_rv(client_vm, guest_vm, params)
 

--- a/tests/rv_connect.py
+++ b/tests/rv_connect.py
@@ -286,16 +286,25 @@ def run_rv_connect(test, params, env):
       password = "123456", timeout=int(params.get("login_timeout", 360)))
 
 
-    utils_spice.wait_timeout(15)
+    utils_spice.wait_timeout(60)
+
+    output = client_session.cmd('cat /etc/redhat-release')
+    isRHEL7 = "release 7." in output
 
     logging.info("Restarting GDM session on client")
-    client_root_session.cmd("killall gdm-binary")
+    if isRHEL7:
+        client_root_session.cmd("killall gdm")
+    else:
+        client_root_session.cmd("killall gdm-binary")
 
     logging.info("Restarting GDM session on guest")
-    guest_root_session.cmd("killall gdm-binary")
+    if isRHEL7:
+        guest_root_session.cmd("killall gdm")
+    else:
+        guest_root_session.cmd("killall gdm-binary")
 
     #Wait after gdm is restarted before attempting a rv connection.
-    utils_spice.wait_timeout(3)
+    utils_spice.wait_timeout(10)
 
     launch_rv(client_vm, guest_vm, params)
 

--- a/tests/rv_gui.py
+++ b/tests/rv_gui.py
@@ -1,0 +1,328 @@
+"""
+rv_gui.py - A test to run dogtail gui tests from the client.
+            The test also does verification of the gui tests.
+
+Requires:
+1. rv_setup must be run to have dogtail be installed on the client
+2. rv_connect must be run to restart the gdm session.
+              and have to have both client & remote viewer window available.
+"""
+import os, logging
+from autotest.client.shared import error
+from virttest.aexpect import ShellCmdError
+from virttest import utils_net, utils_spice
+
+def getres(vm_session):
+    """
+    Gets the resolution of a VM
+
+    @param vm_session: cmd session of a VM
+    """
+    try:
+        vm_session.cmd("xrandr | grep '*' >/tmp/res")
+        guest_res_raw = vm_session.cmd("cat /tmp/res|awk '{print $1}'")
+        guest_res = guest_res_raw.split()[0]
+    except ShellCmdError:
+        raise error.TestFail("Could not get guest resolution, xrandr output:" +
+                             " %s" % guest_res_raw)
+    except IndexError:
+        raise error.TestFail("Could not get guest resolution, xrandr output:" +
+                             " %s" % guest_res_raw)
+    return guest_res
+
+def getrvgeometry(client_session, host_port, host_ip):
+    """
+    Gets the geometry of the rv_window from the client session
+
+    @param client_session: cmd session of the client.
+    @param host_port: host port where the vms are running
+    @param host_ip: host ip where the vms are running
+    """
+    rv_xinfo_cmd = "xwininfo -name 'spice://%s?port=%s (1) - Remote Viewer'" \
+                   % (host_ip, host_port)
+    rv_xinfo_cmd += " | grep geometry"
+    try:
+        rv_res_raw = client_session.cmd(rv_xinfo_cmd)
+        rv_res_raw = rv_res_raw.split('+')[0]
+        rv_res = rv_res_raw.split()[1]
+        #print rv_res_raw
+        #print rv_res
+    except ShellCmdError:
+        raise error.TestFail("Could not get the geometry of the rv window")
+    except IndexError:
+        raise error.TestFail("Could not get the geometry of the rv window")
+    return rv_res
+
+def getrvcorners(client_session, host_port, host_ip):
+    """
+    Gets the coordinates of the 4 corners of the rv window
+
+    @param client_session: cmd session of the client.
+    @param host_port: host port where the vms are running
+    @param host_ip: host ip where the vms are running
+    """
+    rv_xinfo_cmd = "xwininfo -name 'spice://%s?port=%s (1) - Remote Viewer'" \
+                   % (host_ip, host_port)
+    rv_xinfo_cmd += " | grep Corners"
+    try:
+        rv_corners_raw = client_session.cmd(rv_xinfo_cmd)
+        rv_corners = rv_corners_raw.strip()
+        #print rv_res_raw
+        #print rv_res
+    except ShellCmdError:
+        raise error.TestFail("Could not get the geometry of the rv window")
+    except IndexError:
+        raise error.TestFail("Could not get the geometry of the rv window")
+    return rv_corners
+
+
+def checkgeometryincrease(rv_res, rv_res2, errorstr):
+    """
+    Checks for an increase in resolution or geometry
+
+    @param rv_res: original resolution
+    @param rv_res2: secondary resolution that is greater
+    @errorstr: user defined error string if the check fails
+    """
+    #Get the required information
+    height1 = int(rv_res.split('x')[0])
+    height2 = int(rv_res2.split('x')[0])
+
+    #The second split of - is a workaround because the xwinfo sometimes
+    #prints out dashes after the resolution for some reason.
+    width1 = int(rv_res.split('x')[1].split('-')[0])
+    width2 = int(rv_res2.split('x')[1].split('-')[0])
+
+    #Verify the height of has increased
+    if(height2 > height1):
+        logging.info("Height check was successful")
+    else:
+        raise error.TestFail("Checking height: " + errorstr)
+    #Verify the width of rv window increased after zooming
+    if(width2 > width1):
+        logging.info("Width check was successful")
+    else:
+        raise error.TestFail("Checking width: " + errorstr)
+
+def checkresequal(res1, res2, logmessage):
+    """
+    Checks for an increase in resolution or geometry
+
+    @param rv_res1: original resolution
+    @param rv_res2: secondary resolution that should be equal
+    @logmessage: user defined error string if the check fails
+    """
+    #Verify the resolutions are equal
+    logging.info(logmessage)
+    if res1 == res2:
+        pass
+    else:
+        raise error.TestFail("Resolution of the guest has changed")
+
+def run_rv_gui(test, params, env):
+    """
+    Tests GUI automation of remote-viewer
+
+    @param test: QEMU test object.
+    @param params: Dictionary with the test parameters.
+    @param env: Dictionary with test environment.
+    """
+
+    #Get required paramters
+    host_ip = utils_net.get_host_ip_address(params)
+    screenshot_dir = params.get("screenshot_dir")
+    #screenshot_name = params.get("screenshot_name")
+    screenshot_exp_name = params.get("screenshot_expected_name")
+    expected_rv_corners_fs = "Corners:  +0+0  -0+0  -0-0  +0-0"
+    screenshot_exp_file = ""
+    host_port = None
+    guest_res = ""
+    guest_res2 = ""
+    rv_res = ""
+    rv_res2 = ""
+    rv_binary = params.get("rv_binary", "remote-viewer")
+
+    tests = params.get("rv_gui_test_list").split()
+    errors = 0
+
+    guest_vm = env.get_vm(params["guest_vm"])
+    guest_vm.verify_alive()
+    guest_session = guest_vm.wait_for_login(
+            timeout=int(params.get("login_timeout", 360)))
+    guest_root_session = guest_vm.wait_for_login(
+            timeout=int(params.get("login_timeout", 360)),
+            username="root", password="123456")
+
+
+    #update host_port
+    host_port = guest_vm.get_spice_var("spice_port")
+
+    client_vm = env.get_vm(params["client_vm"])
+    client_vm.verify_alive()
+    client_session = client_vm.wait_for_login(
+            timeout=int(params.get("login_timeout", 360)))
+
+    client_session.cmd("export DISPLAY=:0.0")
+    guest_session.cmd("export DISPLAY=:0.0")
+    client_session.cmd('. /home/test/.dbus/session-bus/`cat ' + \
+                       '/var/lib/dbus/machine-id`-0')
+    client_session.cmd('export DBUS_SESSION_BUS_ADDRESS ' + \
+                       'DBUS_SESSION_BUS_PID DBUS_SESSION_BUS_WINDOWID')
+
+
+    client_session.cmd("cd %s" % params.get("test_script_tgt"))
+    rv_res_orig = getrvgeometry(client_session, host_port, host_ip)
+    logging.info("Executing gui tests: " + str(tests))
+
+    #Go through all tests to be run
+    for i in tests:
+        logging.info("Test: " + i)
+
+        #Verification that needs to be done prior to running the gui test.
+        if "zoom" in i:
+            #Get preliminary information needed for the zoom tests
+            guest_res = getres(guest_session)
+            rv_res = getrvgeometry(client_session, host_port, host_ip)
+
+        # if i in ("screenshot"):
+        if "screenshot" in i:
+            screenshot_exp_file = os.path.join(screenshot_dir, \
+                                               screenshot_exp_name)
+            try:
+                client_session.cmd('[ -e ' + screenshot_exp_file +' ]')
+                client_session.cmd('rm ' + screenshot_exp_file)
+                logging.info("Deleted: " + screenshot_exp_file)
+            except ShellCmdError:
+                logging.info(screenshot_exp_name + " doesn't exist, continue")
+
+        cmd = "./unittests/%s_rv.py" % i
+
+        #Adding parameters to the test
+        if (i == "connect"):
+            cmd += " 'spice://%s:%s'" % (host_ip, host_port)
+
+        #Run the test
+        print "Running test: " + cmd
+        try:
+            logging.info(client_session.cmd(cmd))
+        except:
+            logging.error("Status:         FAIL")
+            errors += 1
+        else:
+            logging.info("Status:         PASS")
+
+        #Wait before doing any verification
+        utils_spice.wait_timeout(5)
+
+        #Verification Needed after the gui test was run
+        if "zoom" in i:
+            guest_res2 = getres(guest_session)
+            rv_res2 = getrvgeometry(client_session, host_port, host_ip)
+            #Check to see that the resolution doesn't change
+            logstr = "Checking that the guest's resolution doesn't change"
+            checkresequal(guest_res, guest_res2, logstr)
+            if i == "zoomin" or i == "zoomin_shortcut":
+                #verify the rv window has increased
+                errorstr = "Checking the rv window's size has increased"
+                logging.info(errorstr)
+                checkgeometryincrease(rv_res, rv_res2, errorstr)
+            if i == "zoomout" or i == "zoomout_shortcut":
+                #verify the rv window has decreased
+                errorstr = "Checking the rv window's size has decreased"
+                logging.info(errorstr)
+                checkgeometryincrease(rv_res2, rv_res, errorstr)
+            if i == "zoomnorm" or i == "zoomnorm_shortcut":
+                errorstr = "Checking the rv window's size is the same as " + \
+                           "it was originally when rv was started."
+                checkresequal(rv_res2, rv_res_orig, errorstr)
+
+        if i in ("quit_menu", "quit_shortcut"):
+            #Verify for quit tests that remote viewer is not running on client
+            try:
+                rvpid = str(client_session.cmd("pgrep remote-viewer"))
+                raise error.TestFail("Remote-viewer is still running: " + rvpid)
+            except ShellCmdError:
+                logging.info("Remote-viewer process is no longer running.")
+        if "screenshot" in i:
+            #Verify the screenshot was created and clean up
+            try:
+                client_session.cmd('[ -e ' + screenshot_exp_file + ' ]')
+                client_session.cmd('rm ' + screenshot_exp_file)
+                print screenshot_exp_name + " was created as expected"
+            except ShellCmdError:
+                raise error.TestFail("Screenshot " + screenshot_exp_file + \
+                                     " was not created")
+        if i == "fullscreen" or i == "fullscreen_shortcut":
+            #Verify that client's res = guests's res
+            guest_res = getres(guest_session)
+            client_res = getres(client_session)
+            rv_geometry = getrvgeometry(client_session, host_port, host_ip)
+            rv_corners = getrvcorners(client_session, host_port, host_ip)
+            if(client_res == guest_res):
+                logging.info("PASS: Guest resolution is the same as the client")
+                #Verification #2, client's res = rv's geometry
+                if(client_res == rv_geometry):
+                    logging.info("PASS client's res = geometry of rv window")
+                else:
+                    raise error.TestFail("Client resolution: " + client_res + \
+                            " differs from  the rv's geometry: " + rv_geometry)
+
+            else:
+                raise error.TestFail("Guest resolution: " + guest_res + \
+                      "differs from the client: " + client_res)
+            #Verification #3, verify the rv window is at the top corner
+            if(rv_corners == expected_rv_corners_fs):
+                logging.info("PASS: rv window is at the top corner: " + \
+                             rv_corners)
+            else:
+                raise error.TestFail("rv window is not at the top corner " + \
+                                     "as expected, it is at: " + rv_corners)
+        #Verify rv window < client's res
+        if i == "leave_fullscreen" or i == "leave_fullscreen_shortcut":
+            rv_corners = getrvcorners(client_session, host_port, host_ip)
+            if(rv_corners != expected_rv_corners_fs):
+                logging.info("PASS: rv window is not at top corner: " + \
+                             rv_corners)
+            else:
+                raise error.TestFail("rv window, leaving full screen failed.")
+
+        if "printscreen" in i:
+            output = guest_root_session.cmd("ps aux | grep gnome-screenshot")
+            index = 1
+            found = 0
+            plist = output.splitlines()
+            for line in plist:
+                print str(index) + " " + line
+                index += 1
+                list2 = line.split()
+                #get gnome-screenshot info
+                gss_pid =  str(list2[1])
+                gss_process_name = str(list2[10])
+                #Verify gnome-screenshot is running and kill it
+                if gss_process_name == "gnome-screenshot":
+                    found = 1
+                    guest_root_session.cmd("kill " + gss_pid)
+                    break
+                else:
+                    continue
+            if not (found):
+                raise error.TestFail("gnome-screenshot is not running.")
+
+        #Verify the shutdown dialog is present
+        if "ctrl_alt_del" in i:
+            #looking for a blank named dialog will not work for RHEL 7
+            #Will need to find a better solution to verify
+            #the shutdown dialog has come up
+            guest_session.cmd("xwininfo -name ''")
+
+        #Verify a connection is established
+        if i == "connect":
+            try:
+                utils_spice.verify_established(client_vm, host_ip, \
+                                               host_port, rv_binary)
+            except utils_spice.RVConnectError:
+                raise error.TestFail("remote-viewer connection failed")
+
+    if errors:
+        raise error.TestFail("%d GUI tests failed, see log for more details" \
+                             % errors)

--- a/tests/rv_gui.py
+++ b/tests/rv_gui.py
@@ -267,7 +267,7 @@ def run_rv_gui(test, params, env):
                            "it was originally when rv was started."
                 checkresequal(rv_res2, rv_res_orig, errorstr)
 
-        if i in ("quit_menu", "quit_shortcut"):
+        if i in ("quit_menu", "quit_shortcut", "close", "close_shortcut"):
             #Verify for quit tests that remote viewer is not running on client
             try:
                 rvpid = str(client_session.cmd("pgrep remote-viewer"))

--- a/tests/rv_gui.py
+++ b/tests/rv_gui.py
@@ -143,7 +143,7 @@ def percentchange(percent, init, post, msg):
         logging.info(msg + str(post) + " is within a valid limit " + \
                      str(lowerlimit) + " and " + str(upperlimit))
     else:
-        errorstr = "Error:" + msg + post + " is outside the " + \
+        errorstr = "Error:" + msg + str(post) + " is outside the " + \
                     "valid limit " + str(lowerlimit) + " and " + str(upperlimit)
         raise error.TestFail(errorstr)
 
@@ -252,22 +252,22 @@ def run_rv_gui(test, params, env):
             #Check to see that the resolution doesn't change
             logstr = "Checking that the guest's resolution doesn't change"
             checkresequal(guest_res, guest_res2, logstr)
-            if i == "zoomin" or i == "zoomin_shortcut":
+            if "zoomin" in i:
                 #verify the rv window has increased
                 errorstr = "Checking the rv window's size has increased"
                 logging.info(errorstr)
                 checkgeometryincrease(rv_res, rv_res2, errorstr)
-            if i == "zoomout" or i == "zoomout_shortcut":
+            if "zoomout" in i:
                 #verify the rv window has decreased
                 errorstr = "Checking the rv window's size has decreased"
                 logging.info(errorstr)
                 checkgeometryincrease(rv_res2, rv_res, errorstr)
-            if i == "zoomnorm" or i == "zoomnorm_shortcut":
+            if "zoomnorm" in i:
                 errorstr = "Checking the rv window's size is the same as " + \
                            "it was originally when rv was started."
                 checkresequal(rv_res2, rv_res_orig, errorstr)
 
-        if i in ("quit_menu", "quit_shortcut", "close", "close_shortcut"):
+        if "quit" in i or "close" in i:
             #Verify for quit tests that remote viewer is not running on client
             try:
                 rvpid = str(client_session.cmd("pgrep remote-viewer"))
@@ -350,10 +350,10 @@ def run_rv_gui(test, params, env):
         if i == "autoresize_on" or i == "autoresize_off":
             logging.info("Attempting to change the window size of rv to:" + \
                          str(changex) + "x" + str(changey))
-            rv_wmctrl_cmd = "wmctrl -r 'spice://%s?port=%s (1) - Remote Viewer'" \
+            wmctrl_cmd = "wmctrl -r 'spice://%s?port=%s (1) - Remote Viewer'" \
                    % (host_ip, host_port)
-            rv_wmctrl_cmd += " -e 0,0,0," + str(changex) + "," + str(changey)
-            output = client_session.cmd(rv_wmctrl_cmd)
+            wmctrl_cmd += " -e 0,0,0," + str(changex) + "," + str(changey)
+            output = client_session.cmd(wmctrl_cmd)
             logging.info("Original res: " + guest_res)
             logging.info("Original geometry: " + rv_res)
             
@@ -382,8 +382,8 @@ def run_rv_gui(test, params, env):
                 #resolution is changed, attempted to match the window
                 logging.info("Checking resolution is changed, attempted" + \
                              " to match the window, when autoresize is on")
-                percentchange(accept_pct, rvheight2, height2, "Height parameter:")
-                percentchange(accept_pct, rvwidth2, width2, "Width parameter:") 
+                percentchange(accept_pct, rvheight2, height2, "Height param:")
+                percentchange(accept_pct, rvwidth2, width2, "Width param:") 
             if i == "autoresize_off":
                 #resolutions did not change
                 logging.info("Checking the resolution does not change" + \

--- a/tests/rv_setup.py
+++ b/tests/rv_setup.py
@@ -1,0 +1,77 @@
+"""
+A setup test to perform the preliminary actions that are required for
+the rest of the tests.
+
+Actions Currently Performed:
+(1) installs dogtail on the client
+(2) performs required setup to get dogtail tests to work
+(2) puts the dogtail scripts onto the client VM
+
+Requires: the client and guest VMs to be setup.
+"""
+
+import logging
+from os import system, getcwd, chdir
+
+def install_dogtail(session, rpm):
+    """
+    installs dogtail on a VM
+
+    @param session: cmd session of a VM
+    @rpm: rpm name for dogtail
+    """
+    logging.info("Installing dogtail from: " + rpm)
+    session.cmd("yum -y localinstall %s" % rpm)
+    if session.cmd_status("rpm -q dogtail"):
+        raise Exception("Failed to install dogtail")
+
+def deploy_tests(vm, params):
+    """
+    Moves the dogtail tests to a vm
+
+    @param vm: a VM
+    @param params: dictionary of paramaters
+    """
+    logging.info("Deploying tests")
+    script_location = params.get("test_script_tgt")
+    old = getcwd()
+    chdir(params.get("test_dir"))
+    system("zip -r tests .")
+    chdir(old)
+    vm.copy_files_to("%s/tests.zip" % params.get("test_dir"), \
+                     "/home/test/tests.zip")
+    session = vm.wait_for_login(
+            timeout = int(params.get("login_timeout", 360)))
+    session.cmd("unzip -o /home/test/tests.zip -d " + script_location)
+    session.cmd("mkdir -p ~/.gconf/desktop/gnome/interface")
+    logging.info("Disabling gconfd")
+    session.cmd("gconftool-2 --shutdown")
+    logging.info("Enabling accessiblity")
+    session.cmd("cp ~/tests/%gconf.xml ~/.gconf/desktop/gnome/interface/")
+
+
+def setup_vm(vm, params):
+    """
+    Setup the vm for GUI testing, install dogtail & move tests over.
+
+    @param vm: a VM
+    @param params: dictionary of test paramaters
+    """
+    session = vm.wait_for_login(username = "root", password = "123456",
+            timeout=int(params.get("login_timeout", 360)))
+    if session.cmd_status("rpm -q dogtail"):
+        install_dogtail(session, params.get("dogtail_rpm"))
+    deploy_tests(vm, params)
+
+def run_rv_setup(test, params, env):
+    """
+    Setup the VMs for remote-viewer testing
+
+    @param test: QEMU test object.
+    @param params: Dictionary with the test parameters.
+    @param env: Dictionary with test environment.
+    """
+
+    for vm in params.get("vms").split():
+        logging.info("Setting up VM: " + vm)
+        setup_vm(env.get_vm(vm), params)


### PR DESCRIPTION
Adding spice GUI tests:
There are 2 major files:
rv_setup.py: Used to install dogtail on the client and copy the dogtail tests to the client
rv_gui.py: Used to execute the GUI test based on input, and will do verification of the test (which can happen both prior to and after the GUI test has been executed).
