### PR TITLE
Listen on all ipv4 and ipv6 addresses if not explicitly set otherwise

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -767,19 +767,13 @@ class VM(virt_vm.BaseVM):
 
             set_value("password=%s", "spice_password", "disable-ticketing")
             if optget("listening_addr") == "ipv4":
-                host_ip = utils_net.get_host_ip_address(self.params)
                 self.spice_options['listening_addr'] = "ipv4"
-                spice_opts.append("addr=%s" % host_ip)
-                # set_value("addr=%s", "listening_addr", )
             elif optget("listening_addr") == "ipv6":
-                host_ip = utils_net.get_host_ip_address(self.params)
-                host_ip_ipv6 = utils_misc.convert_ipv4_to_ipv6(host_ip)
                 self.spice_options['listening_addr'] = "ipv6"
-                spice_opts.append("addr=%s" % host_ip_ipv6)
 
             set_yes_no_value(
                 "disable_copy_paste", yes_value="disable-copy-paste")
-            set_value("addr=%s", "spice_addr")
+            set_value("addr=%s", "spice_addr", "addr=::")
 
             if optget("spice_ssl") == "yes":
                 # SSL only part


### PR DESCRIPTION
Spice server suffers from combo of its own bug of not being able to
listen on more than one address [1] and more importantly, a glibc/RFC
bug that ipv4 wildcard is returned first when app sets AF_PASSIVE flag
on listening socket of AF_UNSPEC or AF_INET family [2][3][4]:
[1] https://bugzilla.redhat.com/show_bug.cgi?id=787256
[2] http://www.sourceware.org/bugzilla/show_bug.cgi?id=9981
[3] https://bugs.launchpad.net/ubuntu/+source/eglibc/+bug/673708
[4] http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=573456
Neither of the bug is going to be fixed anytime soon so let's implement
this simple workaround:

1) when no "spice_addr" is explicitly set by the test, make spice-server
listen on all ipv4 + ipv6 addresses by setting addr to "::" (ipv6 wildcard)

2) drop addr=%s setting when "ipv4" or "ipv6" options are set.
These options are quite misleading anyway as ipv4 is no-op when no addr=
is set (spice-server listens on ipv4 anyway) and "ipv6" with no addr
statement is currently equivalent to setting of "addr=::" - it makes
spice-server listen on ipv6 wildcard but connections over ipv4 are
accepted as well because no socket option that would make spice-server
listen on ipv6 only is set

3) honour any listening address set by a test (don't try to be smarter
than test authors)

When (if ever) get the original bugs fixed, the workaround will turn to
no-op so it should be safe to include it.
